### PR TITLE
allow --ssl and --sslCAFile to pass through 'mongoctl connect'...

### DIFF
--- a/mongoctl/commands/common/connect.py
+++ b/mongoctl/commands/common/connect.py
@@ -26,7 +26,9 @@ SUPPORTED_MONGO_SHELL_OPTIONS = [
     "eval",
     "verbose",
     "ipv6",
-    "port"
+    "port",
+    "ssl",
+    "sslCAFile",
     ]
 
 ###############################################################################

--- a/mongoctl/mongoctl_command_config.py
+++ b/mongoctl/mongoctl_command_config.py
@@ -537,7 +537,25 @@ MONGOCTL_PARSER_DEF = {
                     "nargs": 1
                 },
 
+                {
+                    "name": "ssl",
+                    "type": "optional",
+                    "help": "connect using encrypted channel",
+                    "cmd_arg": [
+                        "--ssl"
+                    ],
+                    "nargs": 0
+                },
 
+                {
+                    "name": "sslCAFile",
+                    "type": "optional",
+                    "help": "file containing list of trusted Certificate Authorities",
+                    "cmd_arg": [
+                        "--sslCAFile"
+                    ],
+                    "nargs": 1
+                },
 
             ]
         },


### PR DESCRIPTION
... and on to 'mongo' client shell