### PR TITLE
Support AuthSource and AuthMechanism

### DIFF
--- a/mongoctl/commands/common/connect.py
+++ b/mongoctl/commands/common/connect.py
@@ -27,6 +27,7 @@ SUPPORTED_MONGO_SHELL_OPTIONS = [
     "verbose",
     "ipv6",
     "port",
+    "authenticationDatabase",
     "ssl",
     "sslCAFile",
     ]
@@ -97,9 +98,12 @@ def open_mongo_shell_to_server(server,
         else:
             database = "admin"
 
-    if username or server.needs_to_auth(database):
+    login_database = shell_options["authenticationDatabase"] \
+        if "authenticationDatabase" in shell_options else database
+
+    if username or server.needs_to_auth(login_database):
         # authenticate and grab a working username/password
-        username, password = server.get_working_login(database, username,
+        username, password = server.get_working_login(login_database, username,
                                                       password)
 
     do_open_mongo_shell_to(server.get_connection_address(),
@@ -144,6 +148,9 @@ def open_mongo_shell_to_uri(uri,
     database = uri_wrapper.database
     username = username if username else uri_wrapper.username
     password = password if password else uri_wrapper.password
+
+    if "authsource" in uri_wrapper.options and "authenticationDatabase" not in shell_options:
+        shell_options["authenticationDatabase"] = uri_wrapper.options["authsource"]
 
     server_or_cluster = repository.build_server_or_cluster_from_uri(uri)
 

--- a/mongoctl/commands/common/connect.py
+++ b/mongoctl/commands/common/connect.py
@@ -28,6 +28,7 @@ SUPPORTED_MONGO_SHELL_OPTIONS = [
     "ipv6",
     "port",
     "authenticationDatabase",
+    "authenticationMechanism",
     "ssl",
     "sslCAFile",
     ]
@@ -151,6 +152,10 @@ def open_mongo_shell_to_uri(uri,
 
     if "authsource" in uri_wrapper.options and "authenticationDatabase" not in shell_options:
         shell_options["authenticationDatabase"] = uri_wrapper.options["authsource"]
+
+    if "authmechanism" in uri_wrapper.options and "authenticationMechanism" not in shell_options:
+        shell_options["authenticationMechanism"] = uri_wrapper.options["authmechanism"]
+
 
     server_or_cluster = repository.build_server_or_cluster_from_uri(uri)
 

--- a/mongoctl/mongo_uri_tools.py
+++ b/mongoctl/mongo_uri_tools.py
@@ -81,6 +81,11 @@ class MongoUriWrapper:
         return self._uri_obj["password"]
 
     ###########################################################################
+    @property
+    def options(self):
+        return self._uri_obj["options"]
+
+    ###########################################################################
     def is_cluster_uri(self):
         return len(self.node_list) > 1
 

--- a/mongoctl/mongoctl_command_config.py
+++ b/mongoctl/mongoctl_command_config.py
@@ -557,6 +557,16 @@ MONGOCTL_PARSER_DEF = {
                 },
 
                 {
+                    "name": "authenticationMechanism",
+                    "type": "optional",
+                    "help": "authentication mechanism",
+                    "cmd_arg": [
+                        "--authenticationMechanism"
+                    ],
+                    "nargs": 1
+                },
+
+                {
                     "name": "ssl",
                     "type": "optional",
                     "help": "connect using encrypted channel",

--- a/mongoctl/mongoctl_command_config.py
+++ b/mongoctl/mongoctl_command_config.py
@@ -547,6 +547,16 @@ MONGOCTL_PARSER_DEF = {
                 },
 
                 {
+                    "name": "authenticationDatabase",
+                    "type": "optional",
+                    "help": "user source (defaults to dbname)",
+                    "cmd_arg": [
+                        "--authenticationDatabase"
+                    ],
+                    "nargs": 1
+                },
+
+                {
                     "name": "ssl",
                     "type": "optional",
                     "help": "connect using encrypted channel",


### PR DESCRIPTION
AuthSource and AuthMechanism are not supported in URLs for `mongoctl connect`.

See Issue #30.

This pull request adds support for the `authSource` and `authMechanism` URL options while also adding support for the `authenticationDatabase` and `authenticationMechanism` command line options.