### PR TITLE
Don't throw pointless errors on dev laptops whose names don't resolve

### DIFF
--- a/mongoctl/utils.py
+++ b/mongoctl/utils.py
@@ -279,7 +279,11 @@ def get_host_ips(host):
     try:
 
         ips = []
-        addr_info = socket.getaddrinfo(host, None)
+        try:
+            addr_info = socket.getaddrinfo(host, None)
+        # Can't resolve -> obviously has no IPs -> return default empty list
+        except socket.gaierror:
+            return ips
         for elem in addr_info:
             ip = elem[4]
             if ip not in ips:


### PR DESCRIPTION
Got kinda sick of always seeing errors like this anytime I use mongoctl or `mongolab run-mongoctl` on my laptop:

> Unable to resolve address 'ec2-54-186-26-13.us-west-2.compute.amazonaws.com' for server 'mothership'. Cause: Invalid host 'tachi'. Cause: [Errno 8] nodename nor servname provided, or not known

This seems like an obvious correctness fix to me - if one is asking for IPs for a host and it doesn't even resolve, simply return empty list instead of erroring out. That way, higher level functions calling it (like...the one trying to determine if the target host is local) can work right instead of erroring out.