### PR TITLE
Continue creating sample files even if .mongoctl dir exists

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,8 +67,7 @@ def copy_sample_configs():
 
         if not os.path.exists(dot_mongoctl_dir):
             os.makedirs(dot_mongoctl_dir)
-        else:
-            return True
+        # even if .mongoctl dir exists, there're cases sample files not created 
 
         os.chown(dot_mongoctl_dir, owner_uid, owner_gid)
         os.chmod(dot_mongoctl_dir, 00755)


### PR DESCRIPTION
Sometimes users could run into "mongoctl error: Config file /Users/<username>/.mongoctl/mongoctl.config does not exist." while running basic commands after installation. 

It's because setup.py found ~/.mongoctl directory was created, while not those sample config files, which could happen in some race conditions e.g. an incomplete/messy un-installation followed by another installation.

Feel it could be safer to always attempt to create sample config files, even though the ~/.mongoctl directory has been created in setup.py, not a big deal in terms of performance impact. 