### PR TITLE
Move an unqualified sleep() closer to where it's apparently needed.

### DIFF
--- a/mongoctl/commands/server/start.py
+++ b/mongoctl/commands/server/start.py
@@ -229,12 +229,11 @@ def _post_server_start(server, server_pid, **kwargs):
 ###############################################################################
 def _post_mongod_server_start(server, server_pid, **kwargs):
     try:
-
-        # sleep for a couple of seconds for the server to catch
-        time.sleep(2)
-
         # skip repl init if running in standalone mode
         if not kwargs.get("standalone"):
+            # sleep for a couple of seconds to allow server to load replicaset
+            # config first
+            time.sleep(2)
             maybe_config_server_repl_set(server, rs_add=kwargs.get("rs_add"),
                                          no_init=kwargs.get("no_init"))
 


### PR DESCRIPTION
According to where it was originally run & comments therein
(7e7fbab8781634afed78c004467c9003caf24a2b) this sleep is only necessary for
servers that have replicasets, so it should probably live inside the
replicaset branch of the code.

Standalone servers, like those used for testing, don't need it.